### PR TITLE
Fix `showToast` when email already verify

### DIFF
--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -120,20 +120,37 @@ export function RegisterForm({ className, ...props }: RegisterFormProps) {
           }),
         })
 
-        showToast({
-          message: `Usuário registrado com sucesso! Para fazer login, por favor, confirme o email enviado para ${values.email}.`,
-          duration: Infinity,
-          variant: 'success',
-          firstButton: {
-            text: 'Verificar Email Agora!',
-            variant: 'default',
-            onClick: () => handleGoVerifyEmailOpt(responseBody.userId),
-          },
-          redirect: {
-            path: `${webserver.host}/verify-email-opt?token=${responseBody.userId}`,
-            countdownSeconds: 5,
-          },
-        })
+        if (responseBody.emailVerified) {
+          showToast({
+            message: 'Usuário registrado com sucesso!',
+            duration: Infinity,
+            variant: 'success',
+            firstButton: {
+              text: 'Fazer Login Agora!',
+              variant: 'default',
+              onClick: () => handleGoToLogin(responseBody.userId),
+            },
+            redirect: {
+              path: `${webserver.host}/login?token=${responseBody.userId}`,
+              countdownSeconds: 3,
+            },
+          })
+        } else {
+          showToast({
+            message: `Usuário registrado com sucesso! Para fazer login, por favor, confirme o email enviado para ${values.email}.`,
+            duration: Infinity,
+            variant: 'success',
+            firstButton: {
+              text: 'Verificar Email Agora!',
+              variant: 'default',
+              onClick: () => handleGoVerifyEmailOpt(responseBody.userId),
+            },
+            redirect: {
+              path: `${webserver.host}/verify-email-opt?token=${responseBody.userId}`,
+              countdownSeconds: 5,
+            },
+          })
+        }
 
         form.reset()
         return

--- a/src/controllers/auth/register/index.ts
+++ b/src/controllers/auth/register/index.ts
@@ -37,13 +37,14 @@ export async function register(req: NextRequest) {
 
       const registerUseCase = makeRegisterUserUseCase()
 
-      const { message, userId, status } =
+      const { message, userId, emailVerified, status } =
         await registerUseCase.execute(parsedData)
 
       return NextResponse.json(
         {
           message,
           userId,
+          emailVerified,
         },
         { status },
       )

--- a/src/use-cases/auth/register/register.ts
+++ b/src/use-cases/auth/register/register.ts
@@ -15,6 +15,7 @@ interface RegisterUseCaseResponse {
   status: number
   message: string
   userId?: string
+  emailVerified?: boolean
 }
 
 export class RegisterUseCase {
@@ -111,6 +112,7 @@ export class RegisterUseCase {
       status: 201,
       message: 'Usuário criado com sucesso!',
       userId: user.id,
+      emailVerified: Boolean(user.emailVerified),
     }
   }
 }


### PR DESCRIPTION
## Fix `showToast` when email already verified

### Problema
Este PR corrige uma situação onde, se um usuário realizasse o login utilizando um provider diferente de credenciais (como Google, Facebook, etc.), havia a possibilidade do email já ter sido verificado. No entanto, ao tentar fazer o login com credenciais (email e senha), o sistema não verificava se o email já estava verificado e, em vez disso, exibia um `toast` pedindo para o usuário verificar o email.

### Solução
Foi realizado um ajuste para garantir que, ao tentar fazer login com credenciais, o sistema verifique se o email já foi verificado anteriormente, independentemente do método de login utilizado. Agora, o campo `emailVerified` é enviado na resposta da autenticação e o frontend faz essa verificação antes de exibir qualquer mensagem ao usuário.

Com essa modificação, se o email já estiver verificado, o sistema mostrará o `toast` correto, evitando confusão e melhorando a experiência do usuário.
